### PR TITLE
Apply context when dispatching event

### DIFF
--- a/src/undom.js
+++ b/src/undom.js
@@ -134,7 +134,7 @@ export default function undom() {
 			do {
 				l = t.__handlers[toLower(event.type)];
 				if (l) for (i=l.length; i--; ) {
-					if ((l[i](event)===false || event._end) && c) break;
+					if ((l[i].call(t, event)===false || event._end) && c) break;
 				}
 			} while (event.bubbles && !(c && event._stop) && (event.target=t=t.parentNode));
 			return !event.defaultPrevented;


### PR DESCRIPTION
`this` inside of event listeners should be the element that the listener was registered on.

Without this, dispatching events on preact elements was failing with `Cannot read property 'click' of undefined` for example