### PR TITLE
Fix default tree

### DIFF
--- a/src/undom.js
+++ b/src/undom.js
@@ -196,8 +196,16 @@ export default function undom() {
 	function createDocument() {
 		let document = new Document();
 		assign(document, document.defaultView = { document, Document, Node, Text, Element, SVGElement:Element, Event });
-		assign(document, { documentElement:document, createElement, createElementNS, createTextNode });
-		document.appendChild(document.body = createElement('body'));
+		assign(document, { createElement, createElementNS, createTextNode });
+		document.appendChild(
+			document.documentElement = createElement('html')
+		);
+		document.documentElement.appendChild(
+			document.head = createElement('head')
+		);
+		document.documentElement.appendChild(
+			document.body = createElement('body')
+		);
 		return document;
 	}
 

--- a/test/undom.js
+++ b/test/undom.js
@@ -10,6 +10,22 @@ describe('undom', () => {
 		expect(document).to.be.an.instanceOf(document.Document);
 	});
 
+	it('should create a valid Document tree', () => {
+		let document = undom();
+		let html = document.documentElement;
+
+		expect(html).to.be.an.instanceOf(document.Element);
+		expect(html).to.have.property('nodeName', 'HTML');
+
+		expect(document.head).to.be.an.instanceOf(document.Element);
+		expect(document.head).to.have.property('nodeName', 'HEAD');
+		expect(document.head).to.have.property('parentNode', html);
+
+		expect(document.body).to.be.an.instanceOf(document.Element);
+		expect(document.body).to.have.property('nodeName', 'BODY');
+		expect(document.body).to.have.property('parentNode', html);
+	});
+
 	describe('createElement()', () => {
 		let document = undom();
 


### PR DESCRIPTION
By default, the `undom` tree was:

```html
<#document>
  <body></body>
</#document>
```

The `documentElement` was pointing to itself & there was no `document.head` reference or element.

This PR changes it to:

```html
<#document>
  <html>
    <head></head>
    <body></body>
  </html>
</#document>
```

The `documentElement` reference correctly points to `html` and `document.head` is now defined.

---

How would one create `undom` plugins? Are there any examples to look at?