### PR TITLE
Instantiable env

### DIFF
--- a/src/undom.js
+++ b/src/undom.js
@@ -21,194 +21,194 @@ const NODE_TYPES = {
 
 function createEnvironment() {
 
-function isElement(node) {
-	return node.nodeType===1;
-}
+	function isElement(node) {
+		return node.nodeType===1;
+	}
 
-class Node {
-	constructor(nodeType, nodeName) {
-		this.nodeType = nodeType;
-		this.nodeName = nodeName;
-		this.childNodes = [];
-	}
-	get nextSibling() {
-		let p = this.parentNode;
-		if (p) return p.childNodes[findWhere(p.childNodes, this, true, true) + 1];
-	}
-	get previousSibling() {
-		let p = this.parentNode;
-		if (p) return p.childNodes[findWhere(p.childNodes, this, true, true) - 1];
-	}
-	get firstChild() {
-		return this.childNodes[0];
-	}
-	get lastChild() {
-		return this.childNodes[this.childNodes.length-1];
-	}
-	appendChild(child) {
-		this.insertBefore(child);
-		return child;
-	}
-	insertBefore(child, ref) {
-		child.remove();
-		child.parentNode = this;
-		if (ref) splice(this.childNodes, ref, child, true);
-		else this.childNodes.push(child);
-		return child;
-	}
-	replaceChild(child, ref) {
-		if (ref.parentNode===this) {
-			this.insertBefore(child, ref);
-			ref.remove();
-			return ref;
+	class Node {
+		constructor(nodeType, nodeName) {
+			this.nodeType = nodeType;
+			this.nodeName = nodeName;
+			this.childNodes = [];
+		}
+		get nextSibling() {
+			let p = this.parentNode;
+			if (p) return p.childNodes[findWhere(p.childNodes, this, true, true) + 1];
+		}
+		get previousSibling() {
+			let p = this.parentNode;
+			if (p) return p.childNodes[findWhere(p.childNodes, this, true, true) - 1];
+		}
+		get firstChild() {
+			return this.childNodes[0];
+		}
+		get lastChild() {
+			return this.childNodes[this.childNodes.length-1];
+		}
+		appendChild(child) {
+			this.insertBefore(child);
+			return child;
+		}
+		insertBefore(child, ref) {
+			child.remove();
+			child.parentNode = this;
+			if (ref) splice(this.childNodes, ref, child, true);
+			else this.childNodes.push(child);
+			return child;
+		}
+		replaceChild(child, ref) {
+			if (ref.parentNode===this) {
+				this.insertBefore(child, ref);
+				ref.remove();
+				return ref;
+			}
+		}
+		removeChild(child) {
+			splice(this.childNodes, child, false, true);
+			return child;
+		}
+		remove() {
+			if (this.parentNode) this.parentNode.removeChild(this);
 		}
 	}
-	removeChild(child) {
-		splice(this.childNodes, child, false, true);
-		return child;
-	}
-	remove() {
-		if (this.parentNode) this.parentNode.removeChild(this);
-	}
-}
 
 
-class Text extends Node {
-	constructor(text) {
-		super(3, '#text');					// TEXT_NODE
-		this.nodeValue = text;
-	}
-	set textContent(text) {
-		this.nodeValue = text;
-	}
-	get textContent() {
-		return this.nodeValue;
-	}
-}
-
-
-class Element extends Node {
-	constructor(nodeType, nodeName) {
-		super(nodeType || 1, nodeName);		// ELEMENT_NODE
-		this.attributes = [];
-		this.__handlers = {};
-		this.style = {};
+	class Text extends Node {
+		constructor(text) {
+			super(3, '#text');					// TEXT_NODE
+			this.nodeValue = text;
+		}
+		set textContent(text) {
+			this.nodeValue = text;
+		}
+		get textContent() {
+			return this.nodeValue;
+		}
 	}
 
-	get className() { return this.getAttribute('class'); }
-	set className(val) { this.setAttribute('class', val); }
 
-	get cssText() { return this.getAttribute('style'); }
-	set cssText(val) { this.setAttribute('style', val); }
+	class Element extends Node {
+		constructor(nodeType, nodeName) {
+			super(nodeType || 1, nodeName);		// ELEMENT_NODE
+			this.attributes = [];
+			this.__handlers = {};
+			this.style = {};
+		}
 
-	get children() {
-		return this.childNodes.filter(isElement);
-	}
+		get className() { return this.getAttribute('class'); }
+		set className(val) { this.setAttribute('class', val); }
 
-	setAttribute(key, value) {
-		this.setAttributeNS(null, key, value);
-	}
-	getAttribute(key) {
-		return this.getAttributeNS(null, key);
-	}
-	removeAttribute(key) {
-		this.removeAttributeNS(null, key);
-	}
+		get cssText() { return this.getAttribute('style'); }
+		set cssText(val) { this.setAttribute('style', val); }
 
-	setAttributeNS(ns, name, value) {
-		let attr = findWhere(this.attributes, createAttributeFilter(ns, name), false, false);
-		if (!attr) this.attributes.push(attr = { ns, name });
-		attr.value = String(value);
-	}
-	getAttributeNS(ns, name) {
-		let attr = findWhere(this.attributes, createAttributeFilter(ns, name), false, false);
-		return attr && attr.value;
-	}
-	removeAttributeNS(ns, name) {
-		splice(this.attributes, createAttributeFilter(ns, name), false, false);
-	}
+		get children() {
+			return this.childNodes.filter(isElement);
+		}
 
-	addEventListener(type, handler) {
-		(this.__handlers[toLower(type)] || (this.__handlers[toLower(type)] = [])).push(handler);
-	}
-	removeEventListener(type, handler) {
-		splice(this.__handlers[toLower(type)], handler, false, true);
-	}
-	dispatchEvent(event) {
-		let t = event.target = this,
-			c = event.cancelable,
-			l, i;
-		do {
-			event.currentTarget = t;
-			l = t.__handlers && t.__handlers[toLower(event.type)];
-			if (l) for (i=l.length; i--; ) {
-				if ((l[i].call(t, event) === false || event._end) && c) {
-					event.defaultPrevented = true;
+		setAttribute(key, value) {
+			this.setAttributeNS(null, key, value);
+		}
+		getAttribute(key) {
+			return this.getAttributeNS(null, key);
+		}
+		removeAttribute(key) {
+			this.removeAttributeNS(null, key);
+		}
+
+		setAttributeNS(ns, name, value) {
+			let attr = findWhere(this.attributes, createAttributeFilter(ns, name), false, false);
+			if (!attr) this.attributes.push(attr = { ns, name });
+			attr.value = String(value);
+		}
+		getAttributeNS(ns, name) {
+			let attr = findWhere(this.attributes, createAttributeFilter(ns, name), false, false);
+			return attr && attr.value;
+		}
+		removeAttributeNS(ns, name) {
+			splice(this.attributes, createAttributeFilter(ns, name), false, false);
+		}
+
+		addEventListener(type, handler) {
+			(this.__handlers[toLower(type)] || (this.__handlers[toLower(type)] = [])).push(handler);
+		}
+		removeEventListener(type, handler) {
+			splice(this.__handlers[toLower(type)], handler, false, true);
+		}
+		dispatchEvent(event) {
+			let t = event.target = this,
+				c = event.cancelable,
+				l, i;
+			do {
+				event.currentTarget = t;
+				l = t.__handlers && t.__handlers[toLower(event.type)];
+				if (l) for (i=l.length; i--; ) {
+					if ((l[i].call(t, event) === false || event._end) && c) {
+						event.defaultPrevented = true;
+					}
 				}
-			}
-		} while (event.bubbles && !(c && event._stop) && (t=t.parentNode));
-		return l!=null;
-	}
-}
-
-
-class Document extends Element {
-	constructor() {
-		super(9, '#document');			// DOCUMENT_NODE
-	}
-
-	createElement(type) {
-		return new Element(null, String(type).toUpperCase());
-	}
-
-	createElementNS(ns, type) {
-		let element = this.createElement(type);
-		element.namespace = ns;
-		return element;
+			} while (event.bubbles && !(c && event._stop) && (t=t.parentNode));
+			return l!=null;
+		}
 	}
 
 
-	createTextNode(text) {
-		return new Text(text);
-	}
-}
+	class Document extends Element {
+		constructor() {
+			super(9, '#document');			// DOCUMENT_NODE
+		}
+
+		createElement(type) {
+			return new Element(null, String(type).toUpperCase());
+		}
+
+		createElementNS(ns, type) {
+			let element = this.createElement(type);
+			element.namespace = ns;
+			return element;
+		}
 
 
-class Event {
-	constructor(type, opts) {
-		this.type = type;
-		this.bubbles = !!(opts && opts.bubbles);
-		this.cancelable = !!(opts && opts.cancelable);
+		createTextNode(text) {
+			return new Text(text);
+		}
 	}
-	stopPropagation() {
-		this._stop = true;
-	}
-	stopImmediatePropagation() {
-		this._end = this._stop = true;
-	}
-	preventDefault() {
-		this.defaultPrevented = true;
-	}
-}
 
 
-/** Create a minimally viable DOM Document
+	class Event {
+		constructor(type, opts) {
+			this.type = type;
+			this.bubbles = !!(opts && opts.bubbles);
+			this.cancelable = !!(opts && opts.cancelable);
+		}
+		stopPropagation() {
+			this._stop = true;
+		}
+		stopImmediatePropagation() {
+			this._end = this._stop = true;
+		}
+		preventDefault() {
+			this.defaultPrevented = true;
+		}
+	}
+
+
+	/** Create a minimally viable DOM Document
  *	@returns {Document} document
  */
 	function createDocument() {
-	let document = new Document();
-	assign(document, document.defaultView = { document, Document, Node, Text, Element, SVGElement: Element, Event });
-	document.appendChild(
-		document.documentElement = document.createElement('html')
-	);
-	document.documentElement.appendChild(
-		document.head = document.createElement('head')
-	);
-	document.documentElement.appendChild(
-		document.body = document.createElement('body')
-	);
-	return document;
-}
+		let document = new Document();
+		assign(document, document.defaultView = { document, Document, Node, Text, Element, SVGElement: Element, Event });
+		document.appendChild(
+			document.documentElement = document.createElement('html')
+		);
+		document.documentElement.appendChild(
+			document.head = document.createElement('head')
+		);
+		document.documentElement.appendChild(
+			document.body = document.createElement('body')
+		);
+		return document;
+	}
 
 	createDocument.env = createEnvironment;
 	return createDocument;

--- a/src/undom.js
+++ b/src/undom.js
@@ -19,6 +19,7 @@ const NODE_TYPES = {
 };
 */
 
+function createEnvironment() {
 
 function isElement(node) {
 	return node.nodeType===1;
@@ -194,7 +195,7 @@ class Event {
 /** Create a minimally viable DOM Document
  *	@returns {Document} document
  */
-export default function createDocument() {
+	function createDocument() {
 	let document = new Document();
 	assign(document, document.defaultView = { document, Document, Node, Text, Element, SVGElement: Element, Event });
 	document.appendChild(
@@ -208,3 +209,9 @@ export default function createDocument() {
 	);
 	return document;
 }
+
+	createDocument.env = createEnvironment;
+	return createDocument;
+}
+
+export default createEnvironment();


### PR DESCRIPTION
This PR builds on #24. In #24, DOM classes/prototypes became shared across all Documents created via `undom()`:

```js
import undom from 'undom';

const doc1 = undom();
const doc2 = undom();
doc1.defaultView.Node === doc1.defaultView.Node  // true
```

With this PR, `undom()` continues to return shared constructors. However, a new `undom.env()` method returns a new factory function (akin to `undom()`) that can be called to create documents with a new set of constructors:

```js
import undom from 'undom';

// as with #24, documents default to the shared environment:
const doc1 = undom();
const doc2 = undom();
doc1.defaultView.Node === doc1.defaultView.Node;

// but now we have an escape hatch:
const env = undom.env();
const doc3 = env();
doc3.defaultView.Node === doc1.defaultView.Node;  // FALSE!
```

This means we still encourage using the shared globals, but allow creating a new set of them if necessary.

It also opens up an interesting option for plugins, which were [proposed a while ago](https://github.com/developit/undom/issues/3#issuecomment-233199487), but would have been difficult to implement.

```js
import undom from 'undom';
import serialization from 'undom/serialization';
import shadow from 'undom/shadow';

function applyPlugin(dom, plugin) {
  plugin(typeof dom==='function' ? dom() : dom);
}

// create a clean environment
const env = undom.env();
applyPlugin(env, serialization);
applyPlugin(env, shadow);

// now all documents created for the environment have those plugins:
const doc1 = env();
const doc2 = env();

// fun part - this works with the default environment too:
applyPlugin(undom, serialization);
const doc3 = undom(); // has the plugin
```