### PR TITLE
Implement Element.tagName and Node.ownerDocument

### DIFF
--- a/src/undom.js
+++ b/src/undom.js
@@ -95,6 +95,7 @@ function createEnvironment() {
 			this.style = {};
 		}
 
+		get tagName() { return this.nodeName; }
 		get className() { return this.getAttribute('class'); }
 		set className(val) { this.setAttribute('class', val); }
 
@@ -158,7 +159,9 @@ function createEnvironment() {
 		}
 
 		createElement(type) {
-			return new Element(null, String(type).toUpperCase());
+			let element = new Element(null, String(type).toUpperCase());
+			element.ownerDocument = this;
+			return element;
 		}
 
 		createElementNS(ns, type) {

--- a/test/undom.js
+++ b/test/undom.js
@@ -33,6 +33,10 @@ describe('undom', () => {
 			expect(document.createElement('div')).to.be.an.instanceOf(document.Element);
 		});
 
+		it('should generate correct ownerDocument', () => {
+			expect(document.createElement('div')).to.have.property('ownerDocument', document);
+		});
+
 		it('should generate correct nodeNames', () => {
 			expect(document.createElement('div')).to.have.property('nodeName', 'DIV');
 			expect(document.createElement('section')).to.have.property('nodeName', 'SECTION');
@@ -50,6 +54,13 @@ describe('undom', () => {
 
 	describe('Element', () => {
 		let document = undom();
+
+		describe('tagName', () => {
+			it('should return the correct tagName', () => {
+				let element = document.createElement('div');
+				expect(element).to.have.property('tagName', 'DIV');
+			});
+		});
 
 		describe('#appendChild', () => {
 			it('should set parentNode', () => {


### PR DESCRIPTION
This PR implements the following APIs:

* [`Element.tagName`](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName)
* [`Node.ownerDocument`](https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument)

It will allow the following code to operate correctly:

```javascript
import React from 'react';
import ReactDOM from 'react-dom';
import undom from 'undom';

// The render function utilizes global variables so you will need this 
// if running it inside Node.js
// globals.window = {HTMLIFrameElement: function() {}}

ReactDOM.render(<p>Hello React!</p>, undom().document.body);
```

### Sidenote

The best scenario would be adding `get ownerDocument` to `Node` instead of monkey patching `Element` at runtime, but currently that's impossible since `Node` is isolated from the environment.