### PR TITLE
basic Deno support

### DIFF
--- a/src/undom.js
+++ b/src/undom.js
@@ -4,7 +4,7 @@ import {
 	splice,
 	findWhere,
 	createAttributeFilter
-} from './util';
+} from './util.js';
 
 /*
 const NODE_TYPES = {


### PR DESCRIPTION
This should be enough to allow the library to be used in Deno directly through some “GitHub as CDN” service. (It works fine for me locally.)

A next step would be to make the library available directly with the correct MIME type, without such services (through e.g. GitHub pages), or even making the repository available on <https://deno.land/x>.